### PR TITLE
Add waitForServer with timeout parametrization

### DIFF
--- a/include/simple_actions/simple_client.hpp
+++ b/include/simple_actions/simple_client.hpp
@@ -100,6 +100,14 @@ public:
   }
 
   /**
+   * @brief Waits for the server to come up. Will fail after the set timeout
+   */
+  bool waitForServer(std::chrono::duration<int64_t, std::milli> timeout)
+  {
+    return client_->wait_for_action_server(timeout);
+  }
+
+  /**
    * @brief Send a goal, and return immediately
    */
   void sendGoal(const typename ACTION_TYPE::Goal& goal_msg, ResultCallback resultCB = nullptr,

--- a/test/smoke.cpp
+++ b/test/smoke.cpp
@@ -38,6 +38,7 @@
 #include <simple_actions/simple_client.hpp>
 #include <simple_actions/simple_server.hpp>
 #include <action_tutorials_interfaces/action/fibonacci.hpp>
+using namespace std::chrono_literals;
 
 bool execute(const action_tutorials_interfaces::action::Fibonacci::Goal&,
              action_tutorials_interfaces::action::Fibonacci::Result&)
@@ -49,6 +50,7 @@ TEST(Smoke, clientTest)
 {
   rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("client_demo");
   simple_actions::SimpleActionClient<action_tutorials_interfaces::action::Fibonacci> client(node, "fibonacci", false);
+  EXPECT_FALSE(client.waitForServer(1s));
 }
 
 TEST(Smoke, serverTest)


### PR DESCRIPTION
It's essentially a fast-forward of the rclcpp `wait_for_action_server` call without clashing with the existing indefinite wait. I had to remove the default "-1" value to achieve that.