### PR TITLE
Add spin_locally flag to execute()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,26 +25,32 @@ find_package(rclpy REQUIRED)
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(action_tutorials_interfaces REQUIRED)
-  ament_add_gtest(${PROJECT_NAME}_utest test/smoke.cpp)
+  ament_add_gtest(${PROJECT_NAME}_smoke_test test/smoke.cpp)
 
-  ament_target_dependencies(${PROJECT_NAME}_utest
+  ament_target_dependencies(${PROJECT_NAME}_smoke_test
     action_tutorials_interfaces
     action_msgs
     rclcpp
     rclcpp_action
   )
-  target_include_directories(${PROJECT_NAME}_utest PUBLIC
+  target_include_directories(${PROJECT_NAME}_smoke_test PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   )
 
-  install(
-    TARGETS
-     ${PROJECT_NAME}_utest
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  ament_add_gtest(${PROJECT_NAME}_complex_test test/complex_setup.cpp)
+
+  ament_target_dependencies(${PROJECT_NAME}_complex_test
+    action_tutorials_interfaces
+    action_msgs
+    rclcpp
+    rclcpp_action
   )
+  target_include_directories(${PROJECT_NAME}_complex_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+
 endif()
 
 install(DIRECTORY include/

--- a/include/simple_actions/simple_client.hpp
+++ b/include/simple_actions/simple_client.hpp
@@ -150,6 +150,11 @@ public:
       {
         rclcpp::spin_some(node_);
       }
+      else
+      {
+        using namespace std::chrono_literals;
+        std::this_thread::sleep_for(10ms);
+      }
     }
     return execute_result_;
   }

--- a/include/simple_actions/simple_client.hpp
+++ b/include/simple_actions/simple_client.hpp
@@ -138,7 +138,7 @@ public:
    * @note: Does not return the ResultCode
    */
   typename ACTION_TYPE::Result& execute(const typename ACTION_TYPE::Goal& goal_msg,
-                                        FeedbackCallback feedbackCB = nullptr)
+                                        FeedbackCallback feedbackCB = nullptr, bool spin_locally = true)
   {
     using std::placeholders::_1;
     using std::placeholders::_2;
@@ -146,7 +146,10 @@ public:
     sendGoal(goal_msg, std::bind(&SimpleActionClient::executeResultCallback, this, _1, _2), feedbackCB);
     while (!execute_result_recieved_ && rclcpp::ok())
     {
-      rclcpp::spin_some(node_);
+      if (spin_locally)
+      {
+        rclcpp::spin_some(node_);
+      }
     }
     return execute_result_;
   }

--- a/test/complex_setup.cpp
+++ b/test/complex_setup.cpp
@@ -1,0 +1,111 @@
+/*********************************************************************
+ * Software License Agreement (BSD License 2.0)
+ *
+ *  Copyright (c) 2023, Metro Robots
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Metro Robots nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: David V. Lu!! */
+
+#include <gtest/gtest.h>
+#include <simple_actions/simple_client.hpp>
+#include <simple_actions/simple_server.hpp>
+#include <action_tutorials_interfaces/action/fibonacci.hpp>
+
+#include <action_tutorials_interfaces/action/fibonacci.hpp>
+#include <simple_actions/simple_client.hpp>
+
+using Fibonacci = action_tutorials_interfaces::action::Fibonacci;
+
+class TestComplexSetup : public ::testing::Test
+{
+protected:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void SetUp()
+  {
+    // Instantiate the action client we test with
+    server_node_ = std::make_shared<rclcpp::Node>("server_node");
+    fibonacci_action_server_ = std::make_shared<simple_actions::SimpleActionServer<Fibonacci>>(
+        server_node_, "/fibonacci", [](const Fibonacci::Goal& /*goal*/, Fibonacci::Result& result) {
+          result.sequence = {0, 1, 1, 2, 3, 5, 8, 13};
+          return true;
+        });
+
+    client_node_ = std::make_shared<rclcpp::Node>("client_node");
+    fibonacci_action_client_ =
+        std::make_shared<simple_actions::SimpleActionClient<Fibonacci>>(client_node_, "/fibonacci");
+
+    executor_.add_node(server_node_);
+    executor_.add_node(client_node_);
+
+    executor_future_handle_ = std::async(std::launch::async, [&]() -> void { executor_.spin(); });
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+
+  void TearDown()
+  {
+    // Clean up resources
+    fibonacci_action_server_.reset();
+    fibonacci_action_client_.reset();
+
+    executor_.cancel();
+  }
+
+  std::shared_ptr<rclcpp::Node> server_node_;
+  std::shared_ptr<rclcpp::Node> client_node_;
+
+  std::shared_ptr<simple_actions::SimpleActionServer<Fibonacci>> fibonacci_action_server_;
+  std::shared_ptr<simple_actions::SimpleActionClient<Fibonacci>> fibonacci_action_client_;
+
+  rclcpp::executors::MultiThreadedExecutor executor_;
+  std::future<void> executor_future_handle_;
+};
+
+TEST_F(TestComplexSetup, succeeds_fine)
+{
+  Fibonacci::Goal goal_msg;
+  goal_msg.order = 10;
+  auto result = fibonacci_action_client_->execute(goal_msg, nullptr, false);
+  EXPECT_EQ(fibonacci_action_client_->getLatestResultCode(), simple_actions::ResultCode::SUCCEEDED);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Left enabled by default to keep existing behaviour.

This allows to turn off local spinning to allow for nodes using this library to run an implicit executor elsewhere.

Note: it may be worth adding a small sleep into the loop in case `spin_locally` is false to avoid hogging the CPU...